### PR TITLE
[CI] Re-enable macOS CI runs

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -39,9 +39,8 @@ jobs:
             shell: cmd
           - os: ubuntu-20.04
             shell: bash
-        # Temporarily disabling macOS CI due to pybind issue, see:
-        #   https://github.com/conan-io/conan-center-index/pull/11075
-        # - os: macos-10.15
+          - os: macos-10.15
+            shell: bash
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,7 @@ jobs:
         - os: windows-2019
           vcvars: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
         - os: ubuntu-20.04
-        # Temporarily disabling macOS CI due to pybind issue, see:
-        #   https://github.com/conan-io/conan-center-index/pull/11075
-        # - os: macos-10.15
+        - os: macos-10.15
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upstream pybind issue fixed.

Signed-off-by: Tom Cowland <tom@foundry.com>