### PR TITLE
[CI] Build wheels for Python 3.12

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,7 +34,7 @@ jobs:
           # These are the platform build strings provided to
           # cibuildwheel, with wildcarding. See
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        python-build: ['cp37*64', 'cp39*64', 'cp310*64', 'cp311*64']
+        python-build: ['cp37*64', 'cp39*64', 'cp310*64', 'cp312*64']
     defaults:
       run:
         # Annoyingly required here since `matrix` isn't available in the
@@ -50,7 +50,7 @@ jobs:
       - name: Build wheels
         run: |
           ${{ matrix.config.preamble }}
-          pip install cibuildwheel==2.11.1
+          pip install cibuildwheel==2.16.1
           cibuildwheel --output-dir wheelhouse src/openassetio-python
         env:
           # Windows + Mac runs use this environment variable, as they


### PR DESCRIPTION
Our current strategy is 'Supported VFX Platform versions + latest', 3.12 was released the other day, so update wheel building as a canary.
