### PR TITLE
[Python] Remove out of date constants

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,11 @@ v1.0.0-alpha.xx
   [#919](https://github.com/OpenAssetIO/OpenAssetIO/issues/919)
   [#913](https://github.com/OpenAssetIO/OpenAssetIO/issues/913)
 
+- Removed out of date constants from the Python `openassetio.constants`
+  module. These have been replaced by domain-specific traits and
+  specifications defined in their own repositories, such as
+  [OpenAssetIO-MediaCreation](https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation).
+
 ### Improvements
 
 - Added paged implementations of `getWithRelationship` and

--- a/src/openassetio-python/package/openassetio/constants.py
+++ b/src/openassetio-python/package/openassetio/constants.py
@@ -23,17 +23,11 @@ See @ref openassetio.log.LoggerInterface for example.
 
 kSupportedAttributeTypes = (str, int, float, bool, type(None))
 
-## @name Field Names
-## Field names are to be used whenever data is get or set from a dictionary by
-## key, rather than through an accessor in some wrapper class (eg:
-## Item/Specification etc...). Bare strings should never be used to help
+## @name Info dict field Names
+## Bare strings should never be used to help
 ## protect against inconsistencies and future changes.
 ##
-## These fields should also be used, if necessary, when declaring derived
-## classes of a @ref Specification.
 ## @{
-
-kField_ItemType = "fnItemType"
 
 # General
 
@@ -48,74 +42,5 @@ kField_Icon = "icon"
 ## can be expensive (particularly in the case of python plug-ins
 ## called from multi-threaded C++).
 kField_EntityReferencesMatchPrefix = "entityReferencesMatchPrefix"
-
-# Files
-
-kField_FilePath = "path"
-kField_FileExtensions = "extensions"
-kField_FileIsEnumerated = "enumerated"
-
-# Hints
-
-kField_HintPath = "pathHint"
-kField_HintFilename = "filenameHint"
-kField_HintName = "nameHint"
-
-# Image data
-
-kField_PixelColorspace = "colorspace"
-kField_PixelAspectRatio = "aspectRatio"
-kField_PixelWidth = "width"
-kField_PixelHeight = "height"
-kField_PixelNumChannels = "numChannels"
-kField_PixelEncoding = "encoding"
-kField_PixelCompression = "compression"
-kField_PixelBitDepth = "bitDepth"
-
-# Task/Editorial
-
-kField_Status = "status"
-
-# Sequence
-
-kField_FrameStart = "startFrame"
-kField_FrameEnd = "endFrame"
-kField_FrameIn = "inFrame"
-kField_FrameOut = "outFrame"
-kField_FrameRate = "frameRate"
-kField_DropFrame = "dropFrame"
-kField_FieldDominance = "fieldDominance"
-
-kField_MediaFrameIn = "mediaInFrame"
-kField_MediaFrameOut = "mediaOutFrame"
-
-## @}
-
-
-## @name Setting Key Names
-## Name for keys in the manager settings dict, where applicable.
-## @{
-
-kSetting_ManagerIdentifier = "OpenAssetIO:managerIdentifier"
-kSetting_LoggingSeverity = "OpenAssetIO:loggingSeverity"
-
-## @}
-
-
-## @name Document actions
-## @see @needsref DocumentLocale
-## @{
-
-kDocumentAction_Save = "save"
-kDocumentAction_SaveAs = "saveAs"
-kDocumentAction_SaveNewVersion = "saveNewVersion"
-
-## @}
-
-
-## @name Version dict keys
-## @{
-
-kVersionDict_OrderKey = "__order__"
 
 ## @}


### PR DESCRIPTION
These constants were a remnant of the old data model, where they were used to define the properties of a Specification. This has been superseded by the trait-gen mechanism, and so they are no longer relevant within the core API.

This leaves a several info dict constants, and others whose use needs validating before they are removed.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
