### PR TITLE
[CI] Re-enable BAL integration tests

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -67,12 +67,10 @@ jobs:
           repository: OpenAssetIO/OpenAssetIO-Manager-BAL
           path: external/BAL
 
-      # Disabled pending https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/47
-      #
-      # - name: Test BAL
-      #   run: |
-      #     python -m pip install ./external/BAL
-      #     python -m pytest -v external/BAL/tests
+      - name: Test BAL
+        run: |
+          python -m pip install ./external/BAL
+          python -m pytest -v external/BAL/tests
 
       - name: Test Simple Resolver
         run: |


### PR DESCRIPTION
As we weren't actually installing BAL we were missing its dependencies, which breaks other tests that use it. BAL should also be up-to-date now too.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
